### PR TITLE
RN 0.6 compatibility + flexible width + more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ static defaultProps = {
 	maxDate: '',
 	infoText: '',
 	infoStyle: {color: '#fff', fontSize: 13},
-	infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'}
+	infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'},
+	removeClippedSubviews: true
 };
 ```
 
@@ -76,7 +77,8 @@ static propTypes = {
 	todayColor: PropTypes.string,
 	infoText: PropTypes.string,
 	infoStyle: PropTypes.object,
-	infoContainerStyle: PropTypes.object
+	infoContainerStyle: PropTypes.object,
+	removeClippedSubviews: PropTypes.bool
 }
 ```
 
@@ -107,7 +109,8 @@ static defaultProps = {
 	maxDate: '',
 	infoText: '',
 	infoStyle: {color: '#fff', fontSize: 13},
-	infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'}
+	infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'},
+	removeClippedSubviews: true
 };
 ```
 
@@ -128,7 +131,8 @@ static propTypes = {
 	todayColor: PropTypes.string,
 	infoText: PropTypes.string,
 	infoStyle: PropTypes.object,
-	infoContainerStyle: PropTypes.object
+	infoContainerStyle: PropTypes.object,
+	removeClippedSubviews: PropTypes.bool
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ static defaultProps = {
 	buttonContainerStyle: {},
 	showReset: true,
 	showClose: true,
+	showSelectionInfo: true,
+	showButton: true,
 	ignoreMinDate: false,
 	onClose: () => {},
 	onSelect: () => {},
@@ -47,7 +49,6 @@ static defaultProps = {
 	infoText: '',
 	infoStyle: {color: '#fff', fontSize: 13},
 	infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'},
-	removeClippedSubviews: true
 };
 ```
 
@@ -66,6 +67,8 @@ static propTypes = {
 	maxDate: PropTypes.string,
 	showReset: PropTypes.bool,
 	showClose: PropTypes.bool,
+	showSelectionInfo: PropTypes.bool,
+	showButton: PropTypes.bool,
 	ignoreMinDate: PropTypes.bool,
 	onClose: PropTypes.func,
 	onSelect: PropTypes.func,
@@ -78,7 +81,6 @@ static propTypes = {
 	infoText: PropTypes.string,
 	infoStyle: PropTypes.object,
 	infoContainerStyle: PropTypes.object,
-	removeClippedSubviews: PropTypes.bool
 }
 ```
 
@@ -110,7 +112,6 @@ static defaultProps = {
 	infoText: '',
 	infoStyle: {color: '#fff', fontSize: 13},
 	infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'},
-	removeClippedSubviews: true
 };
 ```
 
@@ -132,23 +133,9 @@ static propTypes = {
 	infoText: PropTypes.string,
 	infoStyle: PropTypes.object,
 	infoContainerStyle: PropTypes.object,
-	removeClippedSubviews: PropTypes.bool
 }
 ```
 
-
-### New Update
-- Available Dates (enable only available date, eg: ["20170620","20170621","20170622","20170623"])
-- Min. Date (minimum date, disabled all date before minDate, eg: "20170620")
-- Max. Date (maximum date, disabled all date after maxDate, eg: "20170630")
-- Ignore Min. Date (ignore minimum date, allow to change startdate even though the selected date is lower than minDate)
-- Initial month (first month on calendar, string with 'YYYYMM' format, eg: "201710")
-- New component (SingleDatepicker), see above for example
-
-
-Ok, that's all.
-
-Sorry, if this README is so simple and miss something out, this is my first package after all.
-
-Feel free to use this package and contributors are welcome.
-Thank you.
+### Update 23/07/2019
+* RN 0.6 compatibility: replaced ListView by FlatList
+* added more flexible width based on actual container size

--- a/RangeDatepicker/Day.js
+++ b/RangeDatepicker/Day.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import {
 	View,
-	StyleSheet,
 	Text,
 	TouchableWithoutFeedback,
 	Dimensions

--- a/RangeDatepicker/Day.js
+++ b/RangeDatepicker/Day.js
@@ -56,7 +56,7 @@ export default class Day extends React.Component {
 				return (
 					<TouchableWithoutFeedback activeOpacity={1} style={dayStyle}>
 						<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-							<Text style={{...textDayStyle, textAlign: "center", width: Math.floor(DEVICE_WIDTH / 7), backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
+							<Text style={{...textDayStyle, textAlign: "center", width: "14.28%", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
 							{day.date == moment().format("YYYYMMDD") ? (<View style={{position: 'absolute', top:0, bottom:0, left:0, right: 0, justifyContent: 'center', backgroundColor: 'transparent'}}><Text style={{fontSize: Math.floor(DEVICE_WIDTH / 17), fontWeight: 'bold', color: '#ccc', textAlign: 'center'}}>__</Text></View>) : null}
 						</View>
 					</TouchableWithoutFeedback>
@@ -66,7 +66,7 @@ export default class Day extends React.Component {
 				return (
 					<TouchableWithoutFeedback activeOpacity={1} style={dayStyle}>
 						<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-							<Text style={{...textDayStyle, textAlign: "center", width: Math.floor(DEVICE_WIDTH / 7), backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
+							<Text style={{...textDayStyle, textAlign: "center", width: "14.28%", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
 							<View style={{position: 'absolute', top: strikeTop, bottom:0, left:0, right: 0, justifyContent: 'center', backgroundColor: 'transparent'}}><Text style={{fontSize: Math.floor(DEVICE_WIDTH / 17), color: '#ccc', textAlign: 'center'}}>__</Text></View>
 						</View>
 					</TouchableWithoutFeedback>
@@ -76,7 +76,7 @@ export default class Day extends React.Component {
 				return (
 					<TouchableWithoutFeedback activeOpacity={1} style={dayStyle} onPress={() => this.props.onSelectDate(moment(day.date, 'YYYYMMDD'))}>
 						<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-							<Text style={{...textDayStyle, textAlign: "center", width: Math.floor(DEVICE_WIDTH / 7), backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
+							<Text style={{...textDayStyle, textAlign: "center", width: "14.28%", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
 							{day.date == moment().format("YYYYMMDD") ? (<View style={{position: 'absolute', top:0, bottom:0, left:0, right: 0, justifyContent: 'center', backgroundColor: 'transparent'}}><Text style={{fontSize: Math.floor(DEVICE_WIDTH / 17), fontWeight: 'bold', color: dayProps.selectedBackgroundColor, textAlign: 'center'}}>__</Text></View>) : null}
 						</View>
 					</TouchableWithoutFeedback>
@@ -86,7 +86,7 @@ export default class Day extends React.Component {
 			return (
 				<TouchableWithoutFeedback activeOpacity={1} style={dayStyle}>
 					<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-						<Text style={{ ...textDayStyle, textAlign: "center", width: Math.floor(DEVICE_WIDTH / 7), backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{null}</Text>
+						<Text style={{ ...textDayStyle, textAlign: "center", width: "14.28%", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{null}</Text>
 					</View>
 				</TouchableWithoutFeedback>
 			);

--- a/RangeDatepicker/Day.js
+++ b/RangeDatepicker/Day.js
@@ -25,24 +25,24 @@ export default class Day extends React.Component {
 
 	render() {
 		let {day, dayProps} = this.props;
-		let dayStyle = {backgroundColor : 'transparent', position: 'relative'};
+		let dayStyle = {backgroundColor : 'transparent', position: 'relative', width: "14.28%"};
 		let textDayStyle = {color: 'black'};
 
 		switch(day.type){
 			case "single" : 
-				dayStyle = {backgroundColor : dayProps.selectedBackgroundColor, borderRadius: Math.floor(DEVICE_WIDTH / 7) }
+				dayStyle = {backgroundColor : dayProps.selectedBackgroundColor, borderRadius: Math.floor(DEVICE_WIDTH / 7), width: "14.28%" }
 				textDayStyle = {color: dayProps.selectedTextColor};
 				break;
 			case "first" :
-				dayStyle = {backgroundColor : dayProps.selectedBackgroundColor, borderBottomLeftRadius: Math.floor(DEVICE_WIDTH / 7), borderTopLeftRadius: Math.floor(DEVICE_WIDTH / 7) }
+				dayStyle = {backgroundColor : dayProps.selectedBackgroundColor, borderBottomLeftRadius: Math.floor(DEVICE_WIDTH / 7), borderTopLeftRadius: Math.floor(DEVICE_WIDTH / 7), width: "14.28%" }
 				textDayStyle = {color: dayProps.selectedTextColor};
 				break;
 			case "last" :
-				dayStyle = {backgroundColor : dayProps.selectedBackgroundColor, borderBottomRightRadius: Math.floor(DEVICE_WIDTH / 7), borderTopRightRadius: Math.floor(DEVICE_WIDTH / 7) }
+				dayStyle = {backgroundColor : dayProps.selectedBackgroundColor, borderBottomRightRadius: Math.floor(DEVICE_WIDTH / 7), borderTopRightRadius: Math.floor(DEVICE_WIDTH / 7), width: "14.28%" }
 				textDayStyle = {color: dayProps.selectedTextColor};
 				break;
 			case "between" :
-				dayStyle = {backgroundColor : dayProps.selectedBackgroundColor}
+				dayStyle = {backgroundColor : dayProps.selectedBackgroundColor, width: "14.28%"}
 				textDayStyle = {color: dayProps.selectedTextColor};
 				break;
 			case "disabled" :
@@ -56,7 +56,7 @@ export default class Day extends React.Component {
 				return (
 					<TouchableWithoutFeedback activeOpacity={1} style={dayStyle}>
 						<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-							<Text style={{...textDayStyle, textAlign: "center", width: "14.28%", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
+							<Text style={{...textDayStyle, textAlign: "center", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
 							{day.date == moment().format("YYYYMMDD") ? (<View style={{position: 'absolute', top:0, bottom:0, left:0, right: 0, justifyContent: 'center', backgroundColor: 'transparent'}}><Text style={{fontSize: Math.floor(DEVICE_WIDTH / 17), fontWeight: 'bold', color: '#ccc', textAlign: 'center'}}>__</Text></View>) : null}
 						</View>
 					</TouchableWithoutFeedback>
@@ -66,7 +66,7 @@ export default class Day extends React.Component {
 				return (
 					<TouchableWithoutFeedback activeOpacity={1} style={dayStyle}>
 						<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-							<Text style={{...textDayStyle, textAlign: "center", width: "14.28%", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
+							<Text style={{...textDayStyle, textAlign: "center", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
 							<View style={{position: 'absolute', top: strikeTop, bottom:0, left:0, right: 0, justifyContent: 'center', backgroundColor: 'transparent'}}><Text style={{fontSize: Math.floor(DEVICE_WIDTH / 17), color: '#ccc', textAlign: 'center'}}>__</Text></View>
 						</View>
 					</TouchableWithoutFeedback>
@@ -76,7 +76,7 @@ export default class Day extends React.Component {
 				return (
 					<TouchableWithoutFeedback activeOpacity={1} style={dayStyle} onPress={() => this.props.onSelectDate(moment(day.date, 'YYYYMMDD'))}>
 						<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-							<Text style={{...textDayStyle, textAlign: "center", width: "14.28%", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
+							<Text style={{...textDayStyle, textAlign: "center", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
 							{day.date == moment().format("YYYYMMDD") ? (<View style={{position: 'absolute', top:0, bottom:0, left:0, right: 0, justifyContent: 'center', backgroundColor: 'transparent'}}><Text style={{fontSize: Math.floor(DEVICE_WIDTH / 17), fontWeight: 'bold', color: dayProps.selectedBackgroundColor, textAlign: 'center'}}>__</Text></View>) : null}
 						</View>
 					</TouchableWithoutFeedback>
@@ -86,7 +86,7 @@ export default class Day extends React.Component {
 			return (
 				<TouchableWithoutFeedback activeOpacity={1} style={dayStyle}>
 					<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-						<Text style={{ ...textDayStyle, textAlign: "center", width: "14.28%", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{null}</Text>
+						<Text style={{ ...textDayStyle, textAlign: "center", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{null}</Text>
 					</View>
 				</TouchableWithoutFeedback>
 			);

--- a/RangeDatepicker/DayRow.js
+++ b/RangeDatepicker/DayRow.js
@@ -20,7 +20,7 @@ export default class DayRow extends React.Component {
 
 	render() {
 		return (
-			<View style={{ marginBottom: 2, marginTop: 2, flexDirection: 'row', justifyContent: 'space-between'}}>
+			<View style={{ marginBottom: 2, marginTop: 2, flexDirection: 'row', justifyContent: 'space-evenly', flex: 1}}>
 				{
 					this.props.days.map((day, i) => {
 						return (

--- a/RangeDatepicker/DayRow.js
+++ b/RangeDatepicker/DayRow.js
@@ -4,7 +4,6 @@ import {
 	View
 } from 'react-native';
 import Day from './Day';
-import moment from 'moment';
 
 export default class DayRow extends React.Component {
 	constructor(props) {

--- a/RangeDatepicker/DayRow.js
+++ b/RangeDatepicker/DayRow.js
@@ -20,7 +20,7 @@ export default class DayRow extends React.Component {
 
 	render() {
 		return (
-			<View style={{ marginBottom: 2, marginTop: 2, flexDirection: 'row'}}>
+			<View style={{ marginBottom: 2, marginTop: 2, flexDirection: 'row', justifyContent: 'space-between'}}>
 				{
 					this.props.days.map((day, i) => {
 						return (

--- a/RangeDatepicker/Month.js
+++ b/RangeDatepicker/Month.js
@@ -120,7 +120,7 @@ export default class Month extends React.Component {
 		const dayStack = this.getDayStack(moment(month, 'YYYYMM'));
 		return (
 			<View>
-				<Text style={{fontSize: 20, padding: 20}}>{moment(month, 'YYYYMM').format("MMMM YYYY")}</Text>
+				<Text style={{fontSize: 18, padding: 20}}>{moment(month, 'YYYYMM').format("MMMM YYYY")}</Text>
 				<View>
 					{
 						dayStack.map((days, i) => {

--- a/RangeDatepicker/Month.js
+++ b/RangeDatepicker/Month.js
@@ -2,8 +2,6 @@
 import React from 'react';
 import {
 	View,
-	StyleSheet,
-	ScrollView,
 	Text
 } from 'react-native';
 import DayRow from './DayRow'

--- a/RangeDatepicker/Month.js
+++ b/RangeDatepicker/Month.js
@@ -118,7 +118,7 @@ export default class Month extends React.Component {
 		const dayStack = this.getDayStack(moment(month, 'YYYYMM'));
 		return (
 			<View>
-				<Text style={{fontSize: 18, padding: 20}}>{moment(month, 'YYYYMM').format("MMMM YYYY")}</Text>
+				<Text style={{fontSize: 14, padding: 14}}>{moment(month, 'YYYYMM').format("MMMM YYYY")}</Text>
 				<View>
 					{
 						dayStack.map((days, i) => {

--- a/RangeDatepicker/index.js
+++ b/RangeDatepicker/index.js
@@ -9,7 +9,7 @@ import {
   ActivityIndicator,
   InteractionManager,
   Platform,
-  FlatView,
+  FlatList,
   StyleSheet,
   Button,
   Dimensions

--- a/RangeDatepicker/index.js
+++ b/RangeDatepicker/index.js
@@ -207,7 +207,7 @@ export default class RangeDatepicker extends Component {
 	render(){
 		const monthStack = this.ds.cloneWithRows(this.getMonthStack());
 			return (
-				<View style={{backgroundColor: '#fff', zIndex: 1000, alignSelf: 'center'}}>
+				<View style={{backgroundColor: '#fff', zIndex: 1000, alignSelf: 'center', width: '100%'}}>
 					{
 						this.props.showClose || this.props.showReset ?
 							(<View style={{ flexDirection: 'row', justifyContent: "space-between", padding: 20, paddingBottom: 10}}>

--- a/RangeDatepicker/index.js
+++ b/RangeDatepicker/index.js
@@ -3,12 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   Text,
-  TouchableOpacity,
-  TouchableWithoutFeedback,
   View,
-  ActivityIndicator,
-  InteractionManager,
-  Platform,
   FlatList,
   StyleSheet,
   Button,

--- a/RangeDatepicker/index.js
+++ b/RangeDatepicker/index.js
@@ -202,7 +202,6 @@ export default class RangeDatepicker extends Component {
 	}
 
 	render(){
-		const monthStack = this.ds.cloneWithRows(this.getMonthStack());
 			return (
 				<View style={{backgroundColor: '#fff', zIndex: 1000, alignSelf: 'center', width: '100%'}}>
 					{

--- a/RangeDatepicker/index.js
+++ b/RangeDatepicker/index.js
@@ -60,7 +60,9 @@ export default class RangeDatepicker extends Component {
 		infoText: '',
 		infoStyle: {color: '#fff', fontSize: 13},
 		infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'},
-		removeClippedSubviews: true
+		removeClippedSubviews: true,
+		showSelectionInfo: true,
+		showButton: true,
 	};
 
 
@@ -89,7 +91,9 @@ export default class RangeDatepicker extends Component {
 		infoText: PropTypes.string,
 		infoStyle: PropTypes.object,
 		infoContainerStyle: PropTypes.object,
-		removeClippedSubviews: PropTypes.bool
+		removeClippedSubviews: PropTypes.bool,
+		showSelectionInfo: PropTypes.bool,
+		showButton: PropTypes.bool,
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -217,25 +221,31 @@ export default class RangeDatepicker extends Component {
 							:
 							null
 					}
-					<View style={{ flexDirection: 'row', justifyContent: "space-between", paddingHorizontal: 20, paddingBottom: 5, alignItems: 'center'}}>
-						<View style={{flex: 1}}>
-							<Text style={{fontSize: 34, color: '#666'}}>
-								{ this.state.startDate ? moment(this.state.startDate).format("MMM DD YYYY") : this.props.placeHolderStart}
-							</Text>
-						</View>
+					{
+						this.props.showSelectionInfo ? 
+						(
+						<View style={{ flexDirection: 'row', justifyContent: "space-between", paddingHorizontal: 20, paddingBottom: 5, alignItems: 'center'}}>
+							<View style={{flex: 1}}>
+								<Text style={{fontSize: 34, color: '#666'}}>
+									{ this.state.startDate ? moment(this.state.startDate).format("MMM DD YYYY") : this.props.placeHolderStart}
+								</Text>
+							</View>
 
-						<View style={{}}>
-							<Text style={{fontSize: 80}}>
-								/
-							</Text>
-						</View>
+							<View style={{}}>
+								<Text style={{fontSize: 80}}>
+									/
+								</Text>
+							</View>
 
-						<View style={{flex: 1}}>
-							<Text style={{fontSize: 34, color: '#666', textAlign: 'right'}}>
-								{ this.state.untilDate ? moment(this.state.untilDate).format("MMM DD YYYY") : this.props.placeHolderUntil}
-							</Text>
+							<View style={{flex: 1}}>
+								<Text style={{fontSize: 34, color: '#666', textAlign: 'right'}}>
+									{ this.state.untilDate ? moment(this.state.untilDate).format("MMM DD YYYY") : this.props.placeHolderUntil}
+								</Text>
+							</View>
 						</View>
-					</View>
+						) : null
+					}
+					
 					{
 						this.props.infoText != "" && 
 						<View style={this.props.infoContainerStyle}>
@@ -255,12 +265,19 @@ export default class RangeDatepicker extends Component {
 			            initialListSize={1}
 			            showsVerticalScrollIndicator={false}
 						removeClippedSubviews={this.props.removeClippedSubviews} />
-					<View style={[styles.buttonWrapper, this.props.buttonContainerStyle]}>
-						<Button
-							title="Select Date" 
-							onPress={this.handleConfirmDate}
-							color={this.props.buttonColor} />
-					</View>
+
+					{
+						this.props.showButton ? 
+						(
+						<View style={[styles.buttonWrapper, this.props.buttonContainerStyle]}>
+							<Button
+								title="Select Date" 
+								onPress={this.handleConfirmDate}
+								color={this.props.buttonColor} />
+						</View>
+						) : null
+					}	
+					
 				</View>
 			)
 	}

--- a/RangeDatepicker/index.js
+++ b/RangeDatepicker/index.js
@@ -7,13 +7,10 @@ import {
   FlatList,
   StyleSheet,
   Button,
-  Dimensions
 } from 'react-native';
 import Month from './Month';
 // import styles from './styles';
 import moment from 'moment';
-
-const DEVICE_WIDTH = Dimensions.get('window').width;
 
 export default class RangeDatepicker extends Component {
 	constructor(props) {

--- a/RangeDatepicker/index.js
+++ b/RangeDatepicker/index.js
@@ -255,7 +255,7 @@ export default class RangeDatepicker extends Component {
 					<View style={styles.dayHeader}>
 						{
 							this.props.dayHeadings.map((day, i) => {
-								return (<Text style={{width: DEVICE_WIDTH / 7, textAlign: 'center'}} key={i}>{day}</Text>)
+								return (<Text style={{width: "14.28%", textAlign: 'center'}} key={i}>{day}</Text>)
 							})
 						}
 					</View>

--- a/RangeDatepicker/index.js
+++ b/RangeDatepicker/index.js
@@ -59,7 +59,8 @@ export default class RangeDatepicker extends Component {
 		maxDate: '',
 		infoText: '',
 		infoStyle: {color: '#fff', fontSize: 13},
-		infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'}
+		infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'},
+		removeClippedSubviews: true
 	};
 
 
@@ -87,7 +88,8 @@ export default class RangeDatepicker extends Component {
 		todayColor: PropTypes.string,
 		infoText: PropTypes.string,
 		infoStyle: PropTypes.object,
-		infoContainerStyle: PropTypes.object
+		infoContainerStyle: PropTypes.object,
+		removeClippedSubviews: PropTypes.bool
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -251,7 +253,8 @@ export default class RangeDatepicker extends Component {
 			            dataSource={monthStack}
 			            renderRow={this.handleRenderRow}
 			            initialListSize={1}
-			            showsVerticalScrollIndicator={false} />
+			            showsVerticalScrollIndicator={false}
+						removeClippedSubviews={this.props.removeClippedSubviews} />
 					<View style={[styles.buttonWrapper, this.props.buttonContainerStyle]}>
 						<Button
 							title="Select Date" 

--- a/RangeDatepicker/index.js
+++ b/RangeDatepicker/index.js
@@ -9,7 +9,7 @@ import {
   ActivityIndicator,
   InteractionManager,
   Platform,
-  ListView,
+  FlatView,
   StyleSheet,
   Button,
   Dimensions
@@ -23,7 +23,6 @@ const DEVICE_WIDTH = Dimensions.get('window').width;
 export default class RangeDatepicker extends Component {
 	constructor(props) {
 		super(props);
-    	this.ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 != r2});
 		this.state = {
 			startDate: props.startDate && moment(props.startDate, 'YYYYMMDD'),
 			untilDate: props.untilDate && moment(props.untilDate, 'YYYYMMDD'),
@@ -60,7 +59,6 @@ export default class RangeDatepicker extends Component {
 		infoText: '',
 		infoStyle: {color: '#fff', fontSize: 13},
 		infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'},
-		removeClippedSubviews: true,
 		showSelectionInfo: true,
 		showButton: true,
 	};
@@ -91,7 +89,6 @@ export default class RangeDatepicker extends Component {
 		infoText: PropTypes.string,
 		infoStyle: PropTypes.object,
 		infoContainerStyle: PropTypes.object,
-		removeClippedSubviews: PropTypes.bool,
 		showSelectionInfo: PropTypes.bool,
 		showButton: PropTypes.bool,
 	}
@@ -177,7 +174,7 @@ export default class RangeDatepicker extends Component {
 		this.props.onConfirm && this.props.onConfirm(this.state.startDate,this.state.untilDate);
 	}
 
-	handleRenderRow(month) {
+	handleRenderRow(month, index) {
 		const { selectedBackgroundColor, selectedTextColor, todayColor, ignoreMinDate, minDate, maxDate } = this.props;
 		let { availableDates, startDate, untilDate } = this.state;
 
@@ -259,12 +256,14 @@ export default class RangeDatepicker extends Component {
 							})
 						}
 					</View>
-					<ListView
-			            dataSource={monthStack}
-			            renderRow={this.handleRenderRow}
-			            initialListSize={1}
+					<FlatList
+			            data={this.getMonthStack()}
+			            renderItem={ ({item, index}) => { 
+							return this.handleRenderRow(item, index)
+						}}
+						keyExtractor = { (item, index) => index.toString() }
 			            showsVerticalScrollIndicator={false}
-						removeClippedSubviews={this.props.removeClippedSubviews} />
+					/>
 
 					{
 						this.props.showButton ? 

--- a/SingleDatepicker/Day.js
+++ b/SingleDatepicker/Day.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import {
 	View,
-	StyleSheet,
 	Text,
 	TouchableWithoutFeedback,
 	Dimensions
@@ -25,7 +24,7 @@ export default class Day extends React.Component {
 
 	render() {
 		let {day, dayProps} = this.props;
-		let dayStyle = {backgroundColor : 'transparent', position: 'relative'};
+		let dayStyle = {backgroundColor : 'transparent', position: 'relative', width: "14.28%"};
 		let textDayStyle = {color: 'black'};
 
 		switch(day.type){
@@ -50,7 +49,7 @@ export default class Day extends React.Component {
 				return (
 					<TouchableWithoutFeedback activeOpacity={1} style={dayStyle}>
 						<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-							<Text style={{...textDayStyle, textAlign: "center", width: Math.floor(DEVICE_WIDTH / 7), backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
+							<Text style={{...textDayStyle, textAlign: "center", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
 							<View style={{position: 'absolute', top: strikeTop, bottom:0, left:0, right: 0, justifyContent: 'center', backgroundColor: 'transparent'}}><Text style={{fontSize: Math.floor(DEVICE_WIDTH / 17), color: '#ccc', textAlign: 'center'}}>__</Text></View>
 						</View>
 					</TouchableWithoutFeedback>
@@ -60,7 +59,7 @@ export default class Day extends React.Component {
 				return (
 					<TouchableWithoutFeedback activeOpacity={1} style={dayStyle} onPress={() => this.props.onSelectDate(moment(day.date, 'YYYYMMDD'))}>
 						<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-							<Text style={{...textDayStyle, textAlign: "center", width: Math.floor(DEVICE_WIDTH / 7), backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
+							<Text style={{...textDayStyle, textAlign: "center", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{moment(day.date, 'YYYYMMDD').date()}</Text>
 							{day.date == moment().format("YYYYMMDD") ? (<View style={{position: 'absolute', top:0, bottom:0, left:0, right: 0, justifyContent: 'center', backgroundColor: 'transparent'}}><Text style={{fontSize: Math.floor(DEVICE_WIDTH / 17), fontWeight: 'bold', color: dayProps.selectedBackgroundColor, textAlign: 'center'}}>__</Text></View>) : null}
 						</View>
 					</TouchableWithoutFeedback>
@@ -70,7 +69,7 @@ export default class Day extends React.Component {
 			return (
 				<TouchableWithoutFeedback activeOpacity={1} style={dayStyle}>
 					<View style={{...dayStyle, height: Math.floor(DEVICE_WIDTH / 7), justifyContent: 'center'}}>
-						<Text style={{ ...textDayStyle, textAlign: "center", width: Math.floor(DEVICE_WIDTH / 7), backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{null}</Text>
+						<Text style={{ ...textDayStyle, textAlign: "center", backgroundColor: 'transparent', fontSize: Math.floor(DEVICE_WIDTH / 26)}}>{null}</Text>
 					</View>
 				</TouchableWithoutFeedback>
 			);

--- a/SingleDatepicker/index.js
+++ b/SingleDatepicker/index.js
@@ -3,28 +3,19 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   Text,
-  TouchableOpacity,
-  TouchableWithoutFeedback,
   View,
-  ActivityIndicator,
-  InteractionManager,
-  Platform,
-  ListView,
+  FlatList,
   StyleSheet,
-  Button,
   Dimensions
 } from 'react-native';
 import Month from './Month';
 // import styles from './styles';
 import moment from 'moment';
 
-const DEVICE_WIDTH = Dimensions.get('window').width;
-
 export default class RangeDatepicker extends Component {
 	constructor(props) {
 		super(props);
 
-    	this.ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 != r2});
 		this.state = {
 			availableDates: props.availableDates || null
 		}
@@ -48,7 +39,6 @@ export default class RangeDatepicker extends Component {
 		infoText: '',
 		infoStyle: {color: '#fff', fontSize: 13},
 		infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'},
-		removeClippedSubviews: true
 	};
 
 
@@ -68,7 +58,6 @@ export default class RangeDatepicker extends Component {
 		infoText: PropTypes.string,
 		infoStyle: PropTypes.object,
 		infoContainerStyle: PropTypes.object,
-		removeClippedSubviews: PropTypes.bool
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -94,7 +83,7 @@ export default class RangeDatepicker extends Component {
 		return res;
 	}
 
-	handleRenderRow(month) {
+	handleRenderRow(month, index) {
 		const { selectedBackgroundColor, selectedTextColor, todayColor, ignoreMinDate, minDate, maxDate } = this.props;
 		let { availableDates } = this.state;
 
@@ -118,7 +107,6 @@ export default class RangeDatepicker extends Component {
 	}
 
 	render(){
-		const monthStack = this.ds.cloneWithRows(this.getMonthStack());
 			return (
 				<View style={{backgroundColor: '#fff', zIndex: 1000, alignSelf: 'center'}}>
 					{
@@ -140,16 +128,18 @@ export default class RangeDatepicker extends Component {
 					<View style={styles.dayHeader}>
 						{
 							this.props.dayHeadings.map((day, i) => {
-								return (<Text style={{width: DEVICE_WIDTH / 7, textAlign: 'center'}} key={i}>{day}</Text>)
+								return (<Text style={{width: "14.28%", textAlign: 'center'}} key={i}>{day}</Text>)
 							})
 						}
 					</View>
-					<ListView
-			            dataSource={monthStack}
-			            renderRow={this.handleRenderRow}
-			            initialListSize={1}
+					<FlatList
+			            data={this.getMonthStack()}
+			            renderItem={ ({item, index}) => { 
+							return this.handleRenderRow(item, index)
+						}}
+						keyExtractor = { (item, index) => index.toString() }
 			            showsVerticalScrollIndicator={false}
-						removeClippedSubviews={this.props.removeClippedSubviews} />
+						/>
 				</View>
 			)
 	}

--- a/SingleDatepicker/index.js
+++ b/SingleDatepicker/index.js
@@ -47,7 +47,8 @@ export default class RangeDatepicker extends Component {
 		maxDate: '',
 		infoText: '',
 		infoStyle: {color: '#fff', fontSize: 13},
-		infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'}
+		infoContainerStyle: {marginRight: 20, paddingHorizontal: 20, paddingVertical: 5, backgroundColor: 'green', borderRadius: 20, alignSelf: 'flex-end'},
+		removeClippedSubviews: true
 	};
 
 
@@ -66,7 +67,8 @@ export default class RangeDatepicker extends Component {
 		todayColor: PropTypes.string,
 		infoText: PropTypes.string,
 		infoStyle: PropTypes.object,
-		infoContainerStyle: PropTypes.object
+		infoContainerStyle: PropTypes.object,
+		removeClippedSubviews: PropTypes.bool
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -146,7 +148,8 @@ export default class RangeDatepicker extends Component {
 			            dataSource={monthStack}
 			            renderRow={this.handleRenderRow}
 			            initialListSize={1}
-			            showsVerticalScrollIndicator={false} />
+			            showsVerticalScrollIndicator={false}
+						removeClippedSubviews={this.props.removeClippedSubviews} />
 				</View>
 			)
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-range-datepicker",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "React native range datepicker (inspired by Airbnb Datepicker)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Previously the calendar was only shown after scrolling if it was rendered in a hidden modal and then shown. Adding removeClippedSubviews={false} to the ListView fixes this issue. Therefore I added removeClippedSubviews it as a parameter to RangeDatepicker and SingleDatepicker.

https://github.com/react-navigation/react-navigation/issues/1238#issuecomment-297213802 